### PR TITLE
Add top-level exports and version with environment configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - enable Kerberos authentication
 - adopt official Mapepire protocol types using dataclasses (#96)
 - Native async support for PEP 249 interface (replace to_thread wrapper) #95
+- Improve public API surface and top-level exports #94
 
 ## [v0.2.0](https://github.com/Mapepire-IBMi/mapepire-python/releases/tag/v0.2.0) - 2024-11-26
 - replace `websocket-client` with `websockets`

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
       - [1.1.2 Other Platforms](#112-other-platforms)
   - [2. Passing the connection details as a dictionary](#2-passing-the-connection-details-as-a-dictionary)
   - [3. Using a config file (`.ini`) to store the connection details](#3-using-a-config-file-ini-to-store-the-connection-details)
+  - [4. Using environment variables](#4-using-environment-variables)
   - [TLS Configuration](#tls-configuration)
 - [Usage](#usage)
   - [1. Using the `SQLJob` object to run queries synchronously](#1-using-the-sqljob-object-to-run-queries-synchronously)
@@ -121,18 +122,19 @@ with connect(creds) as conn:
  >
  > - More info TLS Configuration [here](#tls-configuration)
 
-There are three ways to configure mapepire server connection details using `mapepire-python`:
+There are four ways to configure mapepire server connection details using `mapepire-python`:
 
 1. Using the `DaemonServer` object
 2. Passing the connection details as a dictionary
 3. Using a config file (`.ini`) to store the connection details
+4. Using environment variables
 
 ## 1. Using the `DaemonServer` object
 
-to use the `DaemonServer` object, you will need to import the `DaemonServer` class from the `mapepire_python.data_types` module:
+`DaemonServer` is importable directly from `mapepire_python`:
 
 ```python
-from mapepire_python.data_types import DaemonServer
+from mapepire_python import DaemonServer
 
 creds = DaemonServer(
     host="SERVER",
@@ -145,8 +147,7 @@ creds = DaemonServer(
 Once you have created the `DaemonServer` object, you can pass it to the `SQLJob` object to connect to the mapepire server:
 
 ```python
-from mapepire_python.client.sql_job import SQLJob
-from mapepire_python.data_types import DaemonServer
+from mapepire_python import SQLJob, DaemonServer
 
 creds = DaemonServer(
     host="SERVER",
@@ -165,7 +166,7 @@ If your IBM i is configured to support Kerberos authentication, you can authenti
 
 If your Windows machine is part of a Kerberos realm and supports SSPI authentication, you can authenticate by creating the `DaemonServer` as shown below:
 ```python
-from mapepire_python.data_types import DaemonServer
+from mapepire_python import DaemonServer
 from mapepire_python.authentication.kerberosTokenProvider import KerberosTokenProvider
 
 creds = DaemonServer(
@@ -195,7 +196,7 @@ Optional Parameters:
 2. `krb5_mech`: The Kerberos 5 mechanism to use (if not default)
 
 ```python
-from mapepire_python.data_types import DaemonServer
+from mapepire_python import DaemonServer
 from mapepire_python.authentication.kerberosTokenProvider import KerberosTokenProvider
 
 token_provider = KerberosTokenProvider(
@@ -220,7 +221,7 @@ job = SQLJob(creds)
 You can also use a dictionary to configure the connection details:
 
 ```python
-from mapepire_python.client.sql_job import SQLJob
+from mapepire_python import SQLJob
 
 creds = {
   "host": "SERVER",
@@ -253,12 +254,51 @@ Then you can create a `SQLJob` object by passing the path to the `.ini` file whi
 
 
 ```python
-from mapepire_python.client.sql_job import SQLJob
+from mapepire_python import SQLJob
 
 job = SQLJob("./mapepire.ini", section="mapepire")
 ```
 
 The `section` argument is optional and allows you to specify a specific section in the `.ini` file where the connection details are stored. This allows you to store multiple connection details to different systems in the same file. If you do not specify a `section`, the first section in the file will be used. 
+
+## 4. Using environment variables
+
+You can configure connection credentials through environment variables, avoiding the need to pass them explicitly in code:
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `MAPEPIRE_HOST` | Yes | — | Server hostname |
+| `MAPEPIRE_USER` | Yes | — | Database user |
+| `MAPEPIRE_PASSWORD` | Yes | — | Database password |
+| `MAPEPIRE_PORT` | No | `8076` | Server port |
+| `MAPEPIRE_CA_PATH` | No | — | Path to CA certificate file |
+
+Set the variables in your shell:
+
+```bash
+export MAPEPIRE_HOST=myibmi.example.com
+export MAPEPIRE_USER=myuser
+export MAPEPIRE_PASSWORD=mypassword
+```
+
+Then `connect()` and `async_connect()` can be called with no arguments:
+
+```python
+from mapepire_python import connect
+
+with connect() as conn:
+    with conn.execute("select * from sample.employee") as cursor:
+        print(cursor.fetchone())
+```
+
+You can also create a `DaemonServer` directly from env vars:
+
+```python
+from mapepire_python import DaemonServer, SQLJob
+
+creds = DaemonServer.from_env()
+job = SQLJob(creds)
+```
 
 ## TLS Configuration
 
@@ -293,7 +333,7 @@ There are four main ways to run queries using `mapepire-python`:
 ## 1. Using the `SQLJob` object to run queries synchronously
 
 ```python
-from mapepire_python.client.sql_job import SQLJob
+from mapepire_python import SQLJob
 
 with SQLJob("./mapepire.ini") as sql_job:
     with sql_job.query("select * from sample.employee") as query:
@@ -437,7 +477,7 @@ In the ouput above, the query was successful and returned one row of data.
 To create and run a query in a single step, use the `query_and_run` method: 
 
 ```python
-from mapepire_python.client.sql_job import SQLJob
+from mapepire_python import SQLJob
 
 with SQLJob("./mapepire.ini") as sql_job:
     # query automatically closed after running
@@ -451,7 +491,7 @@ The `PoolJob` object can be used to create and run queries asynchronously:
 
 ```python
 import asyncio
-from mapepire_python.pool.pool_job import PoolJob
+from mapepire_python import PoolJob
 
 async def main():
     async with PoolJob("./mapepire.ini") as pool_job:
@@ -467,7 +507,7 @@ To run a create and run a query asynchronously in a single step, use the `query_
 
 ```python
 import asyncio
-from mapepire_python.pool.pool_job import PoolJob
+from mapepire_python import PoolJob
 
 async def main():
     async with PoolJob("./mapepire.ini") as pool_job:
@@ -486,7 +526,7 @@ The `Pool` object can be used to create a pool of `PoolJob` objects to run queri
 
 ```python
 import asyncio
-from mapepire_python.pool.pool_client import Pool, PoolOptions
+from mapepire_python import Pool, PoolOptions
 
 async def main():
     async with Pool(
@@ -551,14 +591,14 @@ with connect("./mapepire.ini") as conn:
 
 ## PEP 249 Asynchronous Implementation
 
-The PEP 249 implementation provides a native async interface backed by non-blocking WebSocket I/O — no thread delegation. The `connect` function returns an asynchronous context manager that can be used with the `async with` statement:
+The PEP 249 implementation provides a native async interface backed by non-blocking WebSocket I/O — no thread delegation. Use `async_connect` from the top-level package, or `connect` from `mapepire_python.asyncio`:
 
 ```python
 import asyncio
-from mapepire_python.asyncio import connect
+from mapepire_python import async_connect
 
 async def main():
-    async with connect("./mapepire.ini") as conn:
+    async with async_connect("./mapepire.ini") as conn:
         async with await conn.execute("select * from sample.employee") as cursor:
             result = await cursor.fetchone()
             print(result)
@@ -571,7 +611,7 @@ Fetch multiple rows at once with `fetchmany` or drain the full result set with `
 
 ```python
 async def main():
-    async with connect("./mapepire.ini") as conn:
+    async with async_connect("./mapepire.ini") as conn:
         async with await conn.execute("select * from sample.employee") as cursor:
             page = await cursor.fetchmany(10)   # first 10 rows
             rest = await cursor.fetchall()       # remaining rows
@@ -584,7 +624,7 @@ Stream rows one at a time using `async for`:
 
 ```python
 async def main():
-    async with connect("./mapepire.ini") as conn:
+    async with async_connect("./mapepire.ini") as conn:
         async for row in await conn.execute("select * from sample.employee"):
             print(row)
 

--- a/mapepire_python/__init__.py
+++ b/mapepire_python/__init__.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
+from .asyncio import connect as async_connect
+from .asyncio.connection import AsyncConnection
+from .client.query import QueryState
+from .client.sql_job import SQLJob
 from .core import (
     Connection,
     Cursor,
@@ -14,7 +18,11 @@ from .core import (
     OperationalError,
     ProgrammingError,
 )
-from .data_types import DaemonServer
+from .core.exceptions import CONNECTION_CLOSED, convert_runtime_errors
+from .data_types import DaemonServer, JobStatus, QueryOptions, QueryResult
+from .pool.pool_client import Pool, PoolOptions
+from .pool.pool_job import PoolJob
+from .version import VERSION as __version__
 
 __all__ = [
     "apilevel",
@@ -34,6 +42,17 @@ __all__ = [
     "connect",
     "Connection",
     "Cursor",
+    "DaemonServer",
+    "SQLJob",
+    "PoolJob",
+    "Pool",
+    "PoolOptions",
+    "QueryOptions",
+    "QueryResult",
+    "QueryState",
+    "JobStatus",
+    "async_connect",
+    "AsyncConnection",
 ]
 
 # pylint: disable=invalid-name
@@ -43,7 +62,16 @@ paramstyle = "qmark"
 
 
 def connect(
-    connection_details: Union[DaemonServer, dict, Path], opts: Optional[Dict[str, Any]] = None, **kwargs
+    connection_details: Optional[Union[DaemonServer, dict, Path]] = None,
+    opts: Optional[Dict[str, Any]] = None,
+    **kwargs,
 ) -> Connection:
-    """Connect to a Mapepire Server, returning a connection."""
+    """Connect to a Mapepire Server, returning a connection.
+
+    If connection_details is omitted, credentials are read from environment
+    variables: MAPEPIRE_HOST, MAPEPIRE_USER, MAPEPIRE_PASSWORD, MAPEPIRE_PORT,
+    and MAPEPIRE_CA_PATH.
+    """
+    if connection_details is None:
+        connection_details = DaemonServer.from_env()
     return Connection(connection_details, opts, **kwargs)

--- a/mapepire_python/async_base_job.py
+++ b/mapepire_python/async_base_job.py
@@ -47,8 +47,7 @@ class AsyncBaseJob(BaseJob):
         self.id: Optional[str] = None
 
     async def __aenter__(self):
-        if self.creds:
-            await self.connect(self.creds, **self.kwargs)
+        await self.connect(self.creds, **self.kwargs)
         return self
 
     async def __aexit__(self, *args, **kwargs):
@@ -109,7 +108,7 @@ class AsyncBaseJob(BaseJob):
         return len(self.response_emitter.event_names())
 
     async def connect(  # type: ignore[override]
-        self, db2_server: Union[DaemonServer, Dict[str, Any], Path], **kwargs
+        self, db2_server: Optional[Union[DaemonServer, Dict[str, Any], Path]] = None, **kwargs
     ) -> Any:
         db2_server = self._parse_connection_input(db2_server, **kwargs)
 

--- a/mapepire_python/asyncio/__init__.py
+++ b/mapepire_python/asyncio/__init__.py
@@ -41,7 +41,16 @@ paramstyle = "qmark"
 
 
 def connect(
-    connection_details: Union[DaemonServer, dict, Path], opts: Optional[Dict[str, Any]] = None, **kwargs
+    connection_details: Optional[Union[DaemonServer, dict, Path]] = None,
+    opts: Optional[Dict[str, Any]] = None,
+    **kwargs,
 ) -> AsyncConnection:
-    """Connect to a Mapepire Server, returning a connection."""
+    """Connect to a Mapepire Server, returning an async connection.
+
+    If connection_details is omitted, credentials are read from environment
+    variables: MAPEPIRE_HOST, MAPEPIRE_USER, MAPEPIRE_PASSWORD, MAPEPIRE_PORT,
+    and MAPEPIRE_CA_PATH.
+    """
+    if connection_details is None:
+        connection_details = DaemonServer.from_env()
     return AsyncConnection(connection_details, opts, **kwargs)

--- a/mapepire_python/base_job.py
+++ b/mapepire_python/base_job.py
@@ -18,8 +18,10 @@ class BaseJob:
         self.kwargs = kwargs
 
     def _parse_connection_input(
-        self, db2_server: Union[DaemonServer, Dict[str, Any], Path], **kwargs: Any
+        self, db2_server: Optional[Union[DaemonServer, Dict[str, Any], Path]], **kwargs: Any
     ) -> DaemonServer:
+        if db2_server is None:
+            db2_server = DaemonServer.from_env()
         if isinstance(db2_server, dict):
             db2_server = dict_to_dataclass(db2_server, DaemonServer)
         elif isinstance(db2_server, (str, Path)):
@@ -51,7 +53,7 @@ class BaseJob:
         return f"BaseJob(creds={creds_str}, options={self.options})"
 
     def connect(
-        self, db2_server: Union[DaemonServer, Dict[str, Any], Path], **kwargs
+        self, db2_server: Optional[Union[DaemonServer, Dict[str, Any], Path]] = None, **kwargs
     ) -> Dict[str, Any]:
         raise NotImplementedError()
 

--- a/mapepire_python/client/sql_job.py
+++ b/mapepire_python/client/sql_job.py
@@ -39,8 +39,7 @@ class SQLJob(BaseJob):
         self.id: Optional[str] = None
 
     def __enter__(self):
-        if self.creds:
-            self.connect(self.creds, **self.kwargs)
+        self.connect(self.creds, **self.kwargs)
         return self
 
     def __exit__(self, *args, **kwargs):
@@ -91,7 +90,7 @@ class SQLJob(BaseJob):
 
     @handle_ws_errors
     def connect(
-        self, db2_server: Union[DaemonServer, Dict[str, Any], Path], **kwargs
+        self, db2_server: Optional[Union[DaemonServer, Dict[str, Any], Path]] = None, **kwargs
     ) -> Dict[Any, Any]:
         """create connection to the mapepire server
 

--- a/mapepire_python/data_types.py
+++ b/mapepire_python/data_types.py
@@ -7,6 +7,7 @@
 # these from the protocol's JSON Schema files using datamodel-codegen, which
 # would prevent drift. See issue #96 for details.
 
+import os
 from dataclasses import dataclass, field, fields
 from enum import Enum
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
@@ -14,7 +15,6 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 from dataclasses_json import dataclass_json
 
 from mapepire_python.authentication.kerberosTokenProvider import KerberosTokenProvider
-
 
 def dict_to_dataclass(data: Dict[str, Any], dataclass_type: Any) -> Any:
     field_names = {f.name for f in fields(dataclass_type)}
@@ -92,6 +92,44 @@ class DaemonServer:
         if isinstance(self.password, KerberosTokenProvider):
             return self.password.get_token()
         return self.password
+
+    @classmethod
+    def from_env(cls) -> "DaemonServer":
+        """Create a DaemonServer from environment variables.
+
+        Reads MAPEPIRE_HOST, MAPEPIRE_USER, MAPEPIRE_PASSWORD (required),
+        MAPEPIRE_PORT (default 8076), and MAPEPIRE_CA_PATH (optional).
+        """
+        host = os.environ.get("MAPEPIRE_HOST")
+        user = os.environ.get("MAPEPIRE_USER")
+        password = os.environ.get("MAPEPIRE_PASSWORD")
+        port = os.environ.get("MAPEPIRE_PORT", "8076")
+        ca_path = os.environ.get("MAPEPIRE_CA_PATH")
+
+        missing = [
+            name
+            for name, val in [
+                ("MAPEPIRE_HOST", host),
+                ("MAPEPIRE_USER", user),
+                ("MAPEPIRE_PASSWORD", password),
+            ]
+            if not val
+        ]
+        if missing:
+            raise ValueError(
+                f"Missing required environment variables: {', '.join(missing)}"
+            )
+
+        assert host is not None
+        assert user is not None
+        assert password is not None
+
+        ca: Optional[bytes] = None
+        if ca_path:
+            with open(ca_path, "rb") as f:
+                ca = f.read()
+
+        return cls(host=host, user=user, password=password, port=port, ca=ca)
 
 
 @dataclass_json

--- a/mapepire_python/data_types.py
+++ b/mapepire_python/data_types.py
@@ -127,8 +127,13 @@ class DaemonServer:
 
         ca: Optional[bytes] = None
         if ca_path:
-            with open(ca_path, "rb") as f:
-                ca = f.read()
+            try:
+                with open(ca_path, "rb") as f:
+                    ca = f.read()
+            except FileNotFoundError:
+                raise ValueError(f"CA certificate file not found: {ca_path!r}")
+            except PermissionError:
+                raise ValueError(f"Cannot read CA certificate file (permission denied): {ca_path!r}")
 
         return cls(host=host, user=user, password=password, port=port, ca=ca)
 

--- a/mapepire_python/data_types.py
+++ b/mapepire_python/data_types.py
@@ -16,6 +16,7 @@ from dataclasses_json import dataclass_json
 
 from mapepire_python.authentication.kerberosTokenProvider import KerberosTokenProvider
 
+
 def dict_to_dataclass(data: Dict[str, Any], dataclass_type: Any) -> Any:
     field_names = {f.name for f in fields(dataclass_type)}
     filtered_data = {k: v for k, v in data.items() if k in field_names}


### PR DESCRIPTION


<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #94

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Exported commonly used classes (DaemonServer, SQLJob, PoolJob, Pool, PoolOptions, QueryOptions, QueryResult, QueryState, JobStatus) directly from mapepire_python so users don't have to dig into internal module paths
- Exposed `__version__` at the top level so mapepire_python.`__version__`works like users would expect
- Added environment variable support so connect() can work with no arguments when env vars are set
- Made async connect accessible from a top-level path and documented it clearly
- Updated README with the new import patterns and env var usage

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [X] Change the base branch to `dev` if it is not already.
- [X] I've read and followed all steps in the [Making a pull request](https://github.com/Mapepire-IBMi/mapepire-python/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [X] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/Mapepire-IBMi/mapepire-python/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [X] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
