### PR TITLE
fix: defer connection in context managers when no credentials provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- fix: do not force a connection in `SQLJob.__enter__` / `AsyncSQLJob.__aenter__` when no credentials are provided, restoring the `with SQLJob() as job: job.connect(creds)` pattern (regression from #111)
 - add TLS support
 - enable server certificate verification by default
 - enable Kerberos authentication

--- a/mapepire_python/async_base_job.py
+++ b/mapepire_python/async_base_job.py
@@ -47,7 +47,8 @@ class AsyncBaseJob(BaseJob):
         self.id: Optional[str] = None
 
     async def __aenter__(self):
-        await self.connect(self.creds, **self.kwargs)
+        if self.creds:
+            await self.connect(self.creds, **self.kwargs)
         return self
 
     async def __aexit__(self, *args, **kwargs):

--- a/mapepire_python/client/sql_job.py
+++ b/mapepire_python/client/sql_job.py
@@ -39,7 +39,8 @@ class SQLJob(BaseJob):
         self.id: Optional[str] = None
 
     def __enter__(self):
-        self.connect(self.creds, **self.kwargs)
+        if self.creds:
+            self.connect(self.creds, **self.kwargs)
         return self
 
     def __exit__(self, *args, **kwargs):

--- a/tests/sql_job_context_test.py
+++ b/tests/sql_job_context_test.py
@@ -1,0 +1,39 @@
+"""Regression tests for context-manager connection behavior.
+
+PR #111 removed the ``if self.creds:`` guard from ``SQLJob.__enter__`` and
+``AsyncSQLJob.__aenter__``. Without it, ``with SQLJob() as job:`` (no
+credentials) eagerly calls ``connect(None)`` -> ``DaemonServer.from_env()`` and
+raises ``ValueError`` when no ``MAPEPIRE_*`` environment variables are set,
+breaking the documented "connect later" pattern::
+
+    with SQLJob() as job:
+        job.connect(creds)
+
+These tests lock in the restored behavior: entering a context manager without
+credentials defers the connection instead of raising. They are
+server-independent and run in CI without a live Mapepire server.
+"""
+
+import pytest
+
+from mapepire_python.client.async_sql_job import AsyncSQLJob
+from mapepire_python.client.sql_job import SQLJob
+from mapepire_python.data_types import JobStatus
+
+
+@pytest.fixture(autouse=True)
+def _clear_mapepire_env(monkeypatch):
+    # Exercise the no-credentials path: from_env() must have nothing to read.
+    for var in ("MAPEPIRE_HOST", "MAPEPIRE_USER", "MAPEPIRE_PASSWORD"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_enter_without_creds_defers_connection():
+    with SQLJob() as job:
+        assert job.get_status() == JobStatus.NotStarted
+
+
+@pytest.mark.asyncio
+async def test_aenter_without_creds_defers_connection():
+    async with AsyncSQLJob() as job:
+        assert job.get_status() == JobStatus.NotStarted


### PR DESCRIPTION
## Summary

`with SQLJob() as job:` (and the async `async with AsyncSQLJob() as job:`) currently raises on entry when no credentials are provided, breaking the documented "connect later" pattern:

```python
with SQLJob() as job:
    job.connect(creds)        # never reached — __enter__ already raised
```

This is a regression from #111. That PR removed the `if self.creds:` guard from `SQLJob.__enter__` and `AsyncSQLJob.__aenter__`:

```diff
 def __enter__(self):
-    if self.creds:
-        self.connect(self.creds, **self.kwargs)
+    self.connect(self.creds, **self.kwargs)
     return self
```

With the guard gone, `__enter__` calls `connect(None)` → `DaemonServer.from_env()`, which raises `ValueError: Missing required environment variables: MAPEPIRE_HOST, MAPEPIRE_USER, MAPEPIRE_PASSWORD` whenever those env vars aren't set. The existing `tests/query_manager_test.py::test_context_manager` fails for exactly this reason (server-independent).

## Fix

Restore the `if self.creds:` guard in both the sync and async context managers. Behavior:

- `with SQLJob(creds) as job:` — still auto-connects (unchanged).
- `with SQLJob() as job:` — defers; caller connects manually inside the block (restored).
- Environment-based configuration is unaffected: the documented entrypoints `connect()` / `async_connect()` resolve `DaemonServer.from_env()` *before* constructing the connection, so they never relied on the context manager auto-connecting with `None`.

## Tests

Added `tests/sql_job_context_test.py` — **server-independent** regression tests for both the sync and async context managers, so this is caught in CI even without a live Mapepire server. Verified they fail on the pre-fix code (`ValueError`) and pass after the fix.

Locally (against a live server): `tests/query_manager_test.py` and `tests/pep249_async_test.py` context-manager tests pass; `ruff check . --exclude tests/` and `isort --check .` pass.

## Note on CI

The `Main` workflow has been red since Nov 2025 primarily because the integration tests require a live IBM i server that GitHub-hosted runners can't reach (`ConnectionRefusedError` to the configured test server) — that's an infrastructure issue, out of scope here. This PR fixes the one genuine, server-independent code regression among those failures and adds tests that run green in CI.
