### PR TITLE
ci: update GitHub Actions to current major versions

### DIFF
--- a/.github/actions/setup-venv/action.yml
+++ b/.github/actions/setup-venv/action.yml
@@ -18,7 +18,7 @@ runs:
         sudo apt-get install -y libkrb5-dev
 
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.event_name == 'pull_request'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
                 isort --check .
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
@@ -113,7 +113,7 @@ jobs:
 
       - name: Upload package distribution files
         if: matrix.task.name == 'Build'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: package
           path: dist
@@ -130,12 +130,12 @@ jobs:
     needs: [checks]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
@@ -150,7 +150,7 @@ jobs:
           echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Download package distribution files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: package
           path: dist
@@ -164,7 +164,7 @@ jobs:
           twine upload -u '${{ secrets.PYPI_USERNAME }}' -p '${{ secrets.PYPI_PASSWORD }}' dist/*
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- ci: update GitHub Actions to current majors — `actions/checkout` v3/v4→v6, `actions/setup-python` v5→v6, `actions/upload-artifact` v4→v7, `actions/download-artifact` v4→v8, `softprops/action-gh-release` v2→v3 (consolidates Dependabot PRs #105–#109)
 - perf(pool): parallel pool init/teardown and load-aware connection fan-out so concurrent queries spread across all connections instead of serializing onto one; switch async response routing from `pyee` to a `dict[str, Future]` (O(1) routing, accurate in-flight accounting) and drop the `pyee` dependency (#115)
 - remove outdated Sphinx/ReadTheDocs documentation (superseded by https://mapepire-ibmi.github.io)
 - patch dependency security vulnerabilities by regenerating `uv.lock` (urllib3, cryptography, requests, idna, wheel, virtualenv, filelock, marshmallow, python-dotenv, pytest, black, pygments; tornado dropped with the docs toolchain)


### PR DESCRIPTION
Triage + consolidated update of the open GitHub Actions Dependabot PRs (#105–#109) against the action versions currently on `main`.

The Dependabot PRs were based on stale workflow state (e.g. `main` already uses `checkout@v4` / `setup-python@v5`) and would have needed rebasing + individual CHANGELOG entries. This applies all five bumps directly to current `main` at their latest majors:

| Action | Was (on main) | Now | Used in |
| --- | --- | --- | --- |
| `actions/checkout` | v4 (and v3 in changelog) | **v6** | `main.yml` (checks + release), `changelog.yml` |
| `actions/setup-python` | v5 | **v6** | `setup-venv` composite, release job |
| `actions/upload-artifact` | v4 | **v7** | Build job |
| `actions/download-artifact` | v4 | **v8** | Release job |
| `softprops/action-gh-release` | v2 | **v3** | Release job |

### No-regression notes
- All five are Node 20→24 runtime majors; `ubuntu-latest` runners satisfy the runner requirement.
- `upload-artifact@v7` ↔ `download-artifact@v8` share the same v4-generation artifact backend, so the build→release `package` artifact hand-off stays compatible (the only hard break is v3↔v4).
- `changelog.yml` uses `git merge-base origin/main HEAD` after `checkout@v6` with `fetch-depth: 0`; the only v6 change is auth-token storage location, which does not affect remote/fetch — verified by this PR’s own CHANGELOG check.
- `gh-release@v3` keeps `body_path` / `prerelease` / `files` inputs and `GITHUB_TOKEN` env unchanged.
- `actions/cache@v4` left as-is (no Dependabot PR; out of scope).

The download-artifact and gh-release bumps are release-gated (only run on tag pushes), so CI here exercises checkout/setup-python/upload-artifact; the release-only actions are covered by the compatibility analysis above.

Supersedes #105, #106, #107, #108, #109.