### PR TITLE
fix(ssl): enforce TLS 1.2 minimum in get_certificate

### DIFF
--- a/mapepire_python/ssl.py
+++ b/mapepire_python/ssl.py
@@ -7,6 +7,7 @@ from .data_types import DaemonServer
 
 def get_certificate(creds: DaemonServer) -> Optional[bytes]:
     context = ssl.create_default_context()
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
     context.check_hostname = False
     context.verify_mode = ssl.CERT_NONE
 


### PR DESCRIPTION
## Summary

Resolves [code scanning alert #2](https://github.com/Mapepire-IBMi/mapepire-python/security/code-scanning/2) — **`py/insecure-protocol`: Use of insecure SSL/TLS version** (CWE-327, severity: high).

CodeQL flagged the `SSLContext` created in `get_certificate()` (`mapepire_python/ssl.py`) because it was used to wrap a socket without explicitly forbidding the broken **TLSv1** and **TLSv1.1** protocols. While `ssl.create_default_context()` sets a sane floor on modern CPython, the static analyzer (correctly, as defense-in-depth) wants the minimum version pinned so the guarantee is explicit and independent of the runtime's defaults.

## Change

A single line, exactly the remediation recommended in the alert's help text:

```python
context = ssl.create_default_context()
context.minimum_version = ssl.TLSVersion.TLSv1_2   # <- added
context.check_hostname = False
context.verify_mode = ssl.CERT_NONE
```

This pins the negotiated protocol floor to TLS 1.2, so TLS 1.0/1.1 (and all SSL versions) are rejected during the handshake.

## Verification

- `python -m py_compile mapepire_python/ssl.py` — compiles cleanly.
- Confirmed `context.minimum_version == ssl.TLSVersion.TLSv1_2` (771) and that both `TLSVersion.TLSv1` and `TLSVersion.TLSv1_1` fall below the enforced minimum.
- `ssl.TLSVersion` is available on all supported runtimes (Python ≥ 3.10; added in 3.7).

## Notes

- Scope kept surgical: only the flagged `get_certificate()` context is changed. `_create_ssl_context()` in `websocket.py` uses the same `create_default_context()` helper but was not flagged (its context is handed to the `websockets` library rather than a direct `wrap_socket` sink). Pinning the minimum version there too would be a reasonable defense-in-depth follow-up if desired.