### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,8 +150,8 @@ jobs:
 
       - name: Install requirements
         run: |
-          pip install --upgrade pip setuptools wheel build
-          pip install -e .[dev]
+          pip install --upgrade pip
+          pip install twine packaging
 
       - name: Prepare environment
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- ci: install only `twine`/`packaging` in the release job instead of the full `.[dev]` extra, so it no longer compiles `gssapi` (avoids the `krb5-config: not found` build failure on the release runner)
 
 ## [v0.3.0](https://github.com/Mapepire-IBMi/mapepire-python/releases/tag/v0.3.0) - 2026-06-29
 - ci: update GitHub Actions to current majors — `actions/checkout` v3/v4→v6, `actions/setup-python` v5→v6, `actions/upload-artifact` v4→v7, `actions/download-artifact` v4→v8, `softprops/action-gh-release` v2→v3 (consolidates Dependabot PRs #105–#109)


### PR DESCRIPTION
- ci: install only `twine`/`packaging` in the release job instead of the full `.[dev]` extra, so it no longer compiles `gssapi` (avoids the `krb5-config: not found` build failure on the release runner)
