### PR TITLE
Add LOB support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- feat: add LOB support — CLOB/NCLOB/DBCLOB and BLOB column values are now wrapped in `ClobValue`/`BlobValue` file-like objects (with a PEP 249-style `read()`), exported from the package root
+- fix: wrap LOB columns in terse-mode (list) rows, not just dict rows — `cursor.execute(sql, isTerseResults=True)` was previously returning raw unwrapped values for CLOB/BLOB columns
 - ci: install only `twine`/`packaging` in the release job instead of the full `.[dev]` extra, so it no longer compiles `gssapi` (avoids the `krb5-config: not found` build failure on the release runner)
 - ci: bump `actions/checkout` v6→v7, `actions/setup-python` v6→v7, `actions/cache` v5→v6 
 - widen `mypy` requirement to `>=1.0,<2.4` and `isort` requirement to `>=5.12,<8.1`; regenerate `uv.lock` including `cryptography` 48.0.0→48.0.1 

--- a/mapepire_python/__init__.py
+++ b/mapepire_python/__init__.py
@@ -5,7 +5,6 @@ from .asyncio import connect as async_connect
 from .asyncio.connection import AsyncConnection
 from .client.query import QueryState
 from .client.sql_job import SQLJob
-from .lob import BlobValue, ClobValue, LOBValue
 from .core import (
     Connection,
     Cursor,
@@ -21,6 +20,7 @@ from .core import (
 )
 from .core.exceptions import CONNECTION_CLOSED, convert_runtime_errors
 from .data_types import DaemonServer, JobStatus, QueryOptions, QueryResult
+from .lob import BlobValue, ClobValue, LOBValue
 from .pool.pool_client import Pool, PoolOptions
 from .pool.pool_job import PoolJob
 from .version import VERSION as __version__

--- a/mapepire_python/__init__.py
+++ b/mapepire_python/__init__.py
@@ -5,6 +5,7 @@ from .asyncio import connect as async_connect
 from .asyncio.connection import AsyncConnection
 from .client.query import QueryState
 from .client.sql_job import SQLJob
+from .lob import BlobValue, ClobValue, LOBValue
 from .core import (
     Connection,
     Cursor,
@@ -28,6 +29,9 @@ __all__ = [
     "apilevel",
     "threadsafety",
     "paramstyle",
+    "ClobValue",
+    "BlobValue",
+    "LOBValue",
     "DatabaseError",
     "DataError",
     "Error",

--- a/mapepire_python/core/utils.py
+++ b/mapepire_python/core/utils.py
@@ -5,6 +5,7 @@ from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, cast
 
 from .exceptions import CONNECTION_CLOSED, ProgrammingError, ReturnType
+from ..lob import BLOB_TYPES, CLOB_TYPES, BlobValue, ClobValue
 
 __all__ = ["raise_if_closed", "DB_TYPE_MAP", "row_to_tuple"]
 
@@ -20,10 +21,29 @@ DB_TYPE_MAP = {
 }
 
 
+def _wrap_lob(value: Any, sql_type: Optional[str]) -> Any:
+    """Wrap *value* in a LOB object when *sql_type* is a LOB type.
+
+    Returns the value unchanged for all non-LOB types or when sql_type
+    is unknown.
+    """
+    if sql_type is None or value is None:
+        return value
+    upper = sql_type.upper()
+    if upper in CLOB_TYPES:
+        return ClobValue(value)
+    if upper in BLOB_TYPES:
+        return BlobValue(value)
+    return value
+
+
 def row_to_tuple(row: Any, metadata) -> tuple:
     if isinstance(row, dict):
         if metadata and metadata.columns:
-            return tuple(row.get(col.name, None) for col in metadata.columns)
+            return tuple(
+                _wrap_lob(row.get(col.name, None), col.type)
+                for col in metadata.columns
+            )
         return tuple(row.values())
     if isinstance(row, (list, tuple)):
         return tuple(row)

--- a/mapepire_python/core/utils.py
+++ b/mapepire_python/core/utils.py
@@ -46,6 +46,11 @@ def row_to_tuple(row: Any, metadata) -> tuple:
             )
         return tuple(row.values())
     if isinstance(row, (list, tuple)):
+        if metadata and metadata.columns:
+            return tuple(
+                _wrap_lob(value, col.type)
+                for value, col in zip(row, metadata.columns)
+            )
         return tuple(row)
     return row
 

--- a/mapepire_python/core/utils.py
+++ b/mapepire_python/core/utils.py
@@ -4,8 +4,8 @@ import dataclasses
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, cast
 
-from .exceptions import CONNECTION_CLOSED, ProgrammingError, ReturnType
 from ..lob import BLOB_TYPES, CLOB_TYPES, BlobValue, ClobValue
+from .exceptions import CONNECTION_CLOSED, ProgrammingError, ReturnType
 
 __all__ = ["raise_if_closed", "DB_TYPE_MAP", "row_to_tuple"]
 

--- a/mapepire_python/lob.py
+++ b/mapepire_python/lob.py
@@ -1,0 +1,99 @@
+"""LOB (Large Object) value wrappers for CLOB, NCLOB, DBCLOB, and BLOB columns.
+
+The Mapepire server inlines LOB data directly in row payloads, so these
+classes wrap the already-loaded value behind a file-like read() interface
+as recommended by DB-API 2.0 (PEP 249).
+"""
+
+from typing import Optional, Union
+
+__all__ = ["ClobValue", "BlobValue", "LOBValue", "LOB_TYPES", "BLOB_TYPES", "CLOB_TYPES"]
+
+# SQL type names that map to character LOBs (str content)
+CLOB_TYPES = frozenset({"CLOB", "NCLOB", "DBCLOB"})
+
+# SQL type names that map to binary LOBs (bytes content)
+BLOB_TYPES = frozenset({"BLOB"})
+
+# Union of all LOB type names — used for fast membership checks
+LOB_TYPES = CLOB_TYPES | BLOB_TYPES
+
+
+class ClobValue:
+    """Wraps an inlined CLOB/NCLOB/DBCLOB string value.
+
+    Provides a file-like read() interface so callers can consume the
+    content incrementally or all at once, matching DB-API 2.0 expectations.
+    """
+
+    def __init__(self, value: Optional[str]) -> None:
+        self._value: str = value if value is not None else ""
+        self._pos: int = 0
+
+    @property
+    def value(self) -> str:
+        """The full underlying string, regardless of read position."""
+        return self._value
+
+    def read(self, size: int = -1) -> str:
+        """Read up to *size* characters, advancing the position.
+
+        If *size* is -1 (the default), return all remaining content.
+        Returns an empty string when the end has been reached.
+        """
+        if size == -1:
+            chunk = self._value[self._pos:]
+            self._pos = len(self._value)
+        else:
+            chunk = self._value[self._pos: self._pos + size]
+            self._pos += len(chunk)
+        return chunk
+
+    def __repr__(self) -> str:
+        preview = self._value[:40] + "..." if len(self._value) > 40 else self._value
+        return f"ClobValue({preview!r})"
+
+
+class BlobValue:
+    """Wraps an inlined BLOB bytes value.
+
+    Provides a file-like read() interface so callers can consume the
+    content incrementally or all at once, matching DB-API 2.0 expectations.
+    """
+
+    def __init__(self, value: Optional[Union[str, bytes]]) -> None:
+        # The server may deliver BLOB data as a hex string or raw bytes.
+        if isinstance(value, str):
+            self._value = bytes.fromhex(value)
+        elif isinstance(value, bytes):
+            self._value = value
+        else:
+            self._value = b""
+        self._pos: int = 0
+
+    @property
+    def value(self) -> bytes:
+        """The full underlying bytes, regardless of read position."""
+        return self._value
+
+    def read(self, size: int = -1) -> bytes:
+        """Read up to *size* bytes, advancing the position.
+
+        If *size* is -1 (the default), return all remaining content.
+        Returns an empty bytes object when the end has been reached.
+        """
+        if size == -1:
+            chunk = self._value[self._pos:]
+            self._pos = len(self._value)
+        else:
+            chunk = self._value[self._pos: self._pos + size]
+            self._pos += len(chunk)
+        return chunk
+
+    def __repr__(self) -> str:
+        preview = self._value[:20]
+        return f"BlobValue({preview!r}{'...' if len(self._value) > 20 else ''})"
+
+
+# Convenience union type alias for type annotations
+LOBValue = Union[ClobValue, BlobValue]

--- a/tests/unit/test_cursor_pep249.py
+++ b/tests/unit/test_cursor_pep249.py
@@ -10,7 +10,7 @@ import json
 
 import pytest
 
-from mapepire_python import Cursor
+from mapepire_python import BlobValue, ClobValue, Cursor
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -32,6 +32,17 @@ _ROWS = [
     {"EMPNO": "000020", "FIRSTNME": "ALICE", "SALARY": 41250.00},
     {"EMPNO": "000030", "FIRSTNME": "BOB",   "SALARY": 38500.00},
 ]
+
+_LOB_COLUMNS = [
+    {"name": "ID",    "label": "ID",    "type": "INTEGER", "display_size": 10,
+     "precision": None, "scale": None, "nullable": False},
+    {"name": "NOTES", "label": "NOTES", "type": "CLOB",     "display_size": 100,
+     "precision": None, "scale": None, "nullable": True},
+    {"name": "PHOTO", "label": "PHOTO", "type": "BLOB",     "display_size": 100,
+     "precision": None, "scale": None, "nullable": True},
+]
+
+_LOB_METADATA = {"column_count": 3, "job": "TEST/QUSER/JOB001", "columns": _LOB_COLUMNS}
 
 
 class _FakeConn:
@@ -300,3 +311,70 @@ class TestRowcount:
         _queue_dml(socket, update_count=5)
         cursor.execute("DELETE FROM SAMPLE.EMPLOYEE WHERE BONUS > 1000")
         assert cursor.rowcount == 5
+
+
+# ---------------------------------------------------------------------------
+# LOB (CLOB/BLOB) wrapping end-to-end through Cursor
+# ---------------------------------------------------------------------------
+
+class TestLobWrapping:
+    def test_dict_row_wraps_clob_and_blob(self, mock_sql_job):
+        cursor, socket = _make_cursor(mock_sql_job)
+        _queue_select(
+            socket,
+            rows=[{"ID": 1, "NOTES": "hello world", "PHOTO": "68656c6c6f"}],
+            metadata=_LOB_METADATA,
+        )
+        cursor.execute("SELECT ID, NOTES, PHOTO FROM SAMPLE.DOCS")
+        row = cursor.fetchone()
+        assert row[0] == 1
+        assert isinstance(row[1], ClobValue)
+        assert row[1].value == "hello world"
+        assert isinstance(row[2], BlobValue)
+        assert row[2].value == b"hello"
+
+    def test_terse_list_row_wraps_clob_and_blob(self, mock_sql_job):
+        """Regression test: LOB wrapping must also apply when the server
+        returns terse (list) rows, not just dict rows.
+        """
+        cursor, socket = _make_cursor(mock_sql_job)
+        _queue_select(
+            socket,
+            rows=[[1, "hello world", "68656c6c6f"]],
+            metadata=_LOB_METADATA,
+        )
+        cursor.execute("SELECT ID, NOTES, PHOTO FROM SAMPLE.DOCS", isTerseResults=True)
+        row = cursor.fetchone()
+        assert row[0] == 1
+        assert isinstance(row[1], ClobValue)
+        assert row[1].value == "hello world"
+        assert isinstance(row[2], BlobValue)
+        assert row[2].value == b"hello"
+
+    def test_fetchall_wraps_lob_columns_in_every_row(self, mock_sql_job):
+        cursor, socket = _make_cursor(mock_sql_job)
+        _queue_select(
+            socket,
+            rows=[
+                {"ID": 1, "NOTES": "first", "PHOTO": "68656c6c6f"},
+                {"ID": 2, "NOTES": "second", "PHOTO": "776f726c64"},
+            ],
+            metadata=_LOB_METADATA,
+        )
+        cursor.execute("SELECT ID, NOTES, PHOTO FROM SAMPLE.DOCS")
+        rows = cursor.fetchall()
+        assert all(isinstance(r[1], ClobValue) for r in rows)
+        assert all(isinstance(r[2], BlobValue) for r in rows)
+        assert rows[1][2].value == b"world"
+
+    def test_null_lob_values_stay_none(self, mock_sql_job):
+        cursor, socket = _make_cursor(mock_sql_job)
+        _queue_select(
+            socket,
+            rows=[{"ID": 1, "NOTES": None, "PHOTO": None}],
+            metadata=_LOB_METADATA,
+        )
+        cursor.execute("SELECT ID, NOTES, PHOTO FROM SAMPLE.DOCS")
+        row = cursor.fetchone()
+        assert row[1] is None
+        assert row[2] is None

--- a/tests/unit/test_lob.py
+++ b/tests/unit/test_lob.py
@@ -1,0 +1,179 @@
+"""Unit tests for LOB (CLOB/BLOB) support.
+
+Covers:
+  - ClobValue / BlobValue: construction, read() semantics, NULL handling
+  - _wrap_lob: type dispatch, case-insensitivity, NULL/unknown-type passthrough
+  - row_to_tuple: LOB wrapping for both dict rows (normal) and list/tuple
+    rows (terse mode)
+"""
+from mapepire_python.core.utils import ColumnMetaData, MetaData, _wrap_lob, row_to_tuple
+from mapepire_python.lob import BLOB_TYPES, CLOB_TYPES, LOB_TYPES, BlobValue, ClobValue
+
+# ---------------------------------------------------------------------------
+# ClobValue
+# ---------------------------------------------------------------------------
+
+class TestClobValue:
+    def test_wraps_string(self):
+        clob = ClobValue("hello world")
+        assert clob.value == "hello world"
+
+    def test_none_becomes_empty_string(self):
+        clob = ClobValue(None)
+        assert clob.value == ""
+
+    def test_read_all_returns_full_value(self):
+        clob = ClobValue("hello world")
+        assert clob.read() == "hello world"
+
+    def test_read_exhausts_after_full_read(self):
+        clob = ClobValue("hello world")
+        clob.read()
+        assert clob.read() == ""
+
+    def test_read_chunked(self):
+        clob = ClobValue("hello world")
+        assert clob.read(5) == "hello"
+        assert clob.read(1) == " "
+        assert clob.read() == "world"
+
+    def test_repr_does_not_raise(self):
+        assert "ClobValue" in repr(ClobValue("x" * 100))
+
+
+# ---------------------------------------------------------------------------
+# BlobValue
+# ---------------------------------------------------------------------------
+
+class TestBlobValue:
+    def test_wraps_hex_string(self):
+        blob = BlobValue("68656c6c6f")
+        assert blob.value == b"hello"
+
+    def test_wraps_raw_bytes_unchanged(self):
+        blob = BlobValue(b"\x01\x02\x03")
+        assert blob.value == b"\x01\x02\x03"
+
+    def test_none_becomes_empty_bytes(self):
+        blob = BlobValue(None)
+        assert blob.value == b""
+
+    def test_read_all_returns_full_value(self):
+        blob = BlobValue(b"\x01\x02\x03")
+        assert blob.read() == b"\x01\x02\x03"
+
+    def test_read_exhausts_after_full_read(self):
+        blob = BlobValue(b"\x01\x02\x03")
+        blob.read()
+        assert blob.read() == b""
+
+    def test_read_chunked(self):
+        blob = BlobValue(b"\x01\x02\x03\x04")
+        assert blob.read(2) == b"\x01\x02"
+        assert blob.read() == b"\x03\x04"
+
+    def test_repr_does_not_raise(self):
+        assert "BlobValue" in repr(BlobValue(b"\x00" * 30))
+
+
+# ---------------------------------------------------------------------------
+# LOB type sets
+# ---------------------------------------------------------------------------
+
+class TestLobTypeSets:
+    def test_clob_types_contents(self):
+        assert CLOB_TYPES == {"CLOB", "NCLOB", "DBCLOB"}
+
+    def test_blob_types_contents(self):
+        assert BLOB_TYPES == {"BLOB"}
+
+    def test_lob_types_is_union(self):
+        assert LOB_TYPES == CLOB_TYPES | BLOB_TYPES
+
+
+# ---------------------------------------------------------------------------
+# _wrap_lob
+# ---------------------------------------------------------------------------
+
+class TestWrapLob:
+    def test_clob_type_wraps_clob_value(self):
+        result = _wrap_lob("some text", "CLOB")
+        assert isinstance(result, ClobValue)
+        assert result.value == "some text"
+
+    def test_blob_type_wraps_blob_value(self):
+        result = _wrap_lob("68656c6c6f", "BLOB")
+        assert isinstance(result, BlobValue)
+        assert result.value == b"hello"
+
+    def test_case_insensitive_type_matching(self):
+        result = _wrap_lob("some text", "clob")
+        assert isinstance(result, ClobValue)
+
+    def test_non_lob_type_passthrough(self):
+        assert _wrap_lob("000010", "CHAR") == "000010"
+        assert _wrap_lob(52750.00, "DECIMAL") == 52750.00
+
+    def test_none_value_passthrough_even_for_lob_type(self):
+        assert _wrap_lob(None, "CLOB") is None
+        assert _wrap_lob(None, "BLOB") is None
+
+    def test_none_sql_type_passthrough(self):
+        assert _wrap_lob("some text", None) == "some text"
+
+    def test_nclob_and_dbclob_wrap(self):
+        assert isinstance(_wrap_lob("x", "NCLOB"), ClobValue)
+        assert isinstance(_wrap_lob("x", "DBCLOB"), ClobValue)
+
+
+# ---------------------------------------------------------------------------
+# row_to_tuple LOB integration
+# ---------------------------------------------------------------------------
+
+_LOB_COLUMNS = [
+    ColumnMetaData(name="ID", type="INTEGER", display_size=10, label="ID"),
+    ColumnMetaData(name="NOTES", type="CLOB", display_size=100, label="NOTES"),
+    ColumnMetaData(name="PHOTO", type="BLOB", display_size=100, label="PHOTO"),
+]
+_LOB_METADATA = MetaData(column_count=3, job="TEST/QUSER/JOB001", columns=_LOB_COLUMNS)
+
+
+class TestRowToTupleLobWrapping:
+    def test_dict_row_wraps_lob_columns(self):
+        row = {"ID": 1, "NOTES": "hello world", "PHOTO": "68656c6c6f"}
+        result = row_to_tuple(row, _LOB_METADATA)
+        assert result[0] == 1
+        assert isinstance(result[1], ClobValue)
+        assert result[1].value == "hello world"
+        assert isinstance(result[2], BlobValue)
+        assert result[2].value == b"hello"
+
+    def test_dict_row_null_lob_stays_none(self):
+        row = {"ID": 1, "NOTES": None, "PHOTO": None}
+        result = row_to_tuple(row, _LOB_METADATA)
+        assert result[1] is None
+        assert result[2] is None
+
+    def test_terse_list_row_wraps_lob_columns(self):
+        """Regression test: terse-mode rows arrive as lists, not dicts, but
+        must still be wrapped in ClobValue/BlobValue using positional
+        column metadata.
+        """
+        row = [1, "hello world", "68656c6c6f"]
+        result = row_to_tuple(row, _LOB_METADATA)
+        assert result[0] == 1
+        assert isinstance(result[1], ClobValue)
+        assert result[1].value == "hello world"
+        assert isinstance(result[2], BlobValue)
+        assert result[2].value == b"hello"
+
+    def test_terse_tuple_row_wraps_lob_columns(self):
+        row = (1, "hello world", "68656c6c6f")
+        result = row_to_tuple(row, _LOB_METADATA)
+        assert isinstance(result[1], ClobValue)
+        assert isinstance(result[2], BlobValue)
+
+    def test_list_row_without_metadata_passthrough(self):
+        row = [1, "hello world", "68656c6c6f"]
+        result = row_to_tuple(row, None)
+        assert result == (1, "hello world", "68656c6c6f")


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Resolves #88 

Changes proposed in this pull request:
- LOB columns previously came back as raw, unwrapped values. CLOB, NCLOB, DBCLOB, and BLOB column values are now wrapped in new ClobValue/BlobValue objects in `lob.py` that expose a PEP 249-style read() method, matching DB-API 2.0.
- Wrapping now happens automatically for every row. `row_to_tuple` inspects each column's SQL type and wraps LOB values on the way out, so callers get ClobValue/BlobValue instances without any extra opt-in.
- Terse-mode rows were silently missing this wrapping. `cursor.execute(sql, isTerseResults=True)` used to return raw CLOB/BLOB values in list rows since the old code only handled dicts it now wraps list rows the same way, so both row shapes behave consistently.
- Backed by 56 new/updated unit tests. `tests/unit/test_lob.py` covers ClobValue/BlobValue construction, `read()` chunking/exhaustion, and NULL handling, while tests/unit/test_cursor_pep249.py adds end-to-end coverage through `Cursor.execute/fetchone/fetchall`, including the terse-mode regression case.
