### PR TITLE
declare runtime dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- fix: declare `gssapi` (Linux/macOS) and `pywin32` (Windows) as runtime dependencies instead of dev-only extras, so Kerberos auth works out of the box without a separate `pip install gssapi` — Windows SSPI support still requires `pywin32`'s `sspi` module even though native Windows headers are present, and macOS ships its own GSSAPI/Kerberos framework and headers so no `brew install krb5` is needed there; Linux still needs `krb5-config`/dev headers (e.g. `libkrb5-dev`) available at install time to build `gssapi`
 - ci: install only `twine`/`packaging` in the release job instead of the full `.[dev]` extra, so it no longer compiles `gssapi` (avoids the `krb5-config: not found` build failure on the release runner)
 - ci: bump `actions/checkout` v6→v7, `actions/setup-python` v6→v7, `actions/cache` v5→v6 
 - widen `mypy` requirement to `>=1.0,<2.4` and `isort` requirement to `>=5.12,<8.1`; regenerate `uv.lock` including `cryptography` 48.0.0→48.0.1 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,9 @@ requires-python = ">=3.10"
 dependencies = [
   "dataclasses-json>=0.6.4",
   "websockets>=14.0",
-  "pep249abc"
+  "pep249abc",
+  'gssapi; sys_platform != "win32"',
+  'pywin32; sys_platform == "win32"'
 ]
 license = {file = "LICENSE"}
 
@@ -50,8 +52,6 @@ dev = [
     "pre-commit",
     "python-dotenv",
     "pytest-env",
-    "gssapi",
-    'pywin32; sys_platform == "win32"'
 ]
 
 [tool.setuptools.packages.find]

--- a/uv.lock
+++ b/uv.lock
@@ -543,16 +543,10 @@ sdist = { url = "https://files.pythonhosted.org/packages/23/52/c1e90623c259a42ab
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/d8/dfd7632e42f3028b27fdae1dea0fd967bcee1d9164e0a9fa3946490e6c7a/gssapi-1.11.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:126352502e15dc42f786a4635e5fb4dc8ae4bbc89354e85ab094c478a9e49beb", size = 680076, upload-time = "2026-01-26T21:01:12.11Z" },
     { url = "https://files.pythonhosted.org/packages/0b/25/e668f8bfebdaf132b29a26bbc4cc50c5a624a83c5271e83e69c62c2ac5d3/gssapi-1.11.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:25b3bcf75a0dd5638f02f939a9c40d1c907682ccca69ea1d05ea81ad58ea1022", size = 687299, upload-time = "2026-01-26T21:01:13.933Z" },
-    { url = "https://files.pythonhosted.org/packages/48/57/391fb8511e0e9bd2f86ed342ba65d1d1dbc0bd77d54f1f75ff4e4616df49/gssapi-1.11.1-cp310-cp310-win32.whl", hash = "sha256:e5d01ac02df8fe67c32cd1684c0954e935d50158ebb956fdffbf9aad7695a3b3", size = 749567, upload-time = "2026-01-26T21:01:15.73Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/bf/37a3359ba24d9e422094b749e031116e6613fd038ec0d4c633d210ba314e/gssapi-1.11.1-cp310-cp310-win_amd64.whl", hash = "sha256:0e8b4d76801f2a8f8e6d85746cb9048d47341c6706800b357c61ba09e4741c03", size = 831697, upload-time = "2026-01-26T21:01:17.605Z" },
     { url = "https://files.pythonhosted.org/packages/48/75/3cc18f2d084d19fbba38dc684588cf5f674c647e754f9cf1625bd78c39f8/gssapi-1.11.1-cp311-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2298e5909a8f2d27c29352885a24e4026cfd3fa24fc38d4a0a3743fa5a3e7667", size = 611712, upload-time = "2026-01-26T21:01:19.626Z" },
     { url = "https://files.pythonhosted.org/packages/81/f9/ac0f8c43c209d56c89655f80cd4ae43379f88370d01a7e11f264f081eef5/gssapi-1.11.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:5b60b1f8d8d3e36c025bd3494105de1dfccee578e8de001f423cc094468e3022", size = 642782, upload-time = "2026-01-26T21:01:21.462Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/97/f4ea9248bfdf5fcde2c5bf0bc0e573d212748724a32a5aa1002e11edb760/gssapi-1.11.1-cp311-abi3-win32.whl", hash = "sha256:9738fe0ba163c28ccf521de7520640bde4b135c1b6e87a5ac5a90435369e89c0", size = 699801, upload-time = "2026-01-26T21:01:23.226Z" },
-    { url = "https://files.pythonhosted.org/packages/54/ca/7f839880baf7c365768884161c246a3b6201738722fc7581a995190ec431/gssapi-1.11.1-cp311-abi3-win_amd64.whl", hash = "sha256:96a102ad1ec266e2d843468bf03149982969fc70344f303f81ea20197b80d7a1", size = 781646, upload-time = "2026-01-26T21:01:24.618Z" },
     { url = "https://files.pythonhosted.org/packages/7b/79/9148636b75ca5741ddc9c57c4b256adec422e3a89bca14306d53b48caac9/gssapi-1.11.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:82fba401e9514ad21749b8d8954e2de1c617b0a73204c8598ee84630e23c5810", size = 714379, upload-time = "2026-01-26T21:01:25.961Z" },
     { url = "https://files.pythonhosted.org/packages/ca/77/f34fd81bbccf2e682073964a1b1b0a383e70d02946e472f78881d50cec6f/gssapi-1.11.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cb0250f27d288d4217d7f606d3b68ecb9a10fce9391106129cada96434a685b0", size = 734103, upload-time = "2026-01-26T21:01:27.3Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/34/733a6f3372040992befd1fe62288cafea9fe25acdcf8b663ec8a7857cb69/gssapi-1.11.1-cp314-cp314t-win32.whl", hash = "sha256:b17875d236b8b030a777ee3f3ece55f3d316a91937c37abbc771afe1493703cf", size = 868586, upload-time = "2026-01-26T21:01:29.041Z" },
-    { url = "https://files.pythonhosted.org/packages/10/03/1b71feddb85f945101c3cdc07242805c5e9b48da546f8a922129ad8299e5/gssapi-1.11.1-cp314-cp314t-win_amd64.whl", hash = "sha256:da43c0e0ae84bb9f04c4e016eac6d3826c6357f827183042ba990ccedeeab052", size = 981075, upload-time = "2026-01-26T21:01:30.451Z" },
 ]
 
 [[package]]
@@ -770,7 +764,9 @@ name = "mapepire-python"
 source = { editable = "." }
 dependencies = [
     { name = "dataclasses-json" },
+    { name = "gssapi", marker = "sys_platform != 'win32'" },
     { name = "pep249abc" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "websockets" },
 ]
 
@@ -778,7 +774,6 @@ dependencies = [
 dev = [
     { name = "black" },
     { name = "build" },
-    { name = "gssapi" },
     { name = "isort" },
     { name = "mypy" },
     { name = "packaging" },
@@ -789,7 +784,6 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "python-dotenv" },
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "ruff" },
     { name = "setuptools" },
     { name = "twine" },
@@ -806,7 +800,7 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.3.0,<27.0" },
     { name = "build", marker = "extra == 'dev'" },
     { name = "dataclasses-json", specifier = ">=0.6.4" },
-    { name = "gssapi", marker = "extra == 'dev'" },
+    { name = "gssapi", marker = "sys_platform != 'win32'" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12,<8.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0,<2.4" },
     { name = "packaging", marker = "extra == 'dev'" },
@@ -818,7 +812,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-env", marker = "extra == 'dev'" },
     { name = "python-dotenv", marker = "extra == 'dev'" },
-    { name = "pywin32", marker = "sys_platform == 'win32' and extra == 'dev'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15,<0.16" },
     { name = "setuptools", marker = "extra == 'dev'" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=1.11.0" },


### PR DESCRIPTION
Declares `gssapi` (Linux/macOS) and pywin32 (Windows) as runtime dependencies instead of dev-only extras, so Kerberos auth works out of the box after a plain pip install `mapepire-python` without a separate pip install `gssapi` step. 